### PR TITLE
Fix broken link to 1st paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repo is for listing papers that are useful for understanding IPFS, whether 
 
 ## Papers
 
-- Baumgart, Ingmar and Mies, Sebastian (2007) [S/Kademlia: A Practicable Approach Towards Secure Key-Based Routing](http://www.tm.uka.de/doc/SKademlia_2007.pdf)
+- Baumgart, Ingmar and Mies, Sebastian (2007) [S/Kademlia: A Practicable Approach Towards Secure Key-Based Routing](http://telematics.tm.kit.edu/publications/Files/267/SKademlia_slides_2007.pdf)
 - Benet, Juan (2014) [IPFS - Content Addressed, Versioned, P2P File System](https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf).
 - Freedman, Michael J., Freudenthal, Eric and Mazières, David (2004) [Democratizing Content Publication with Coral](http://www.coralcdn.org/docs/coral-nsdi04.pdf)
 - Mazières, David and Kaashoek, M. Frans (1998) [Escaping the Evils of Centralized Control with self-certifying pathnames](http://www.sigops.org/ew-history/1998/papers/mazieres.ps)


### PR DESCRIPTION
The link to "S/Kademlia: A Practicable Approach Towards Secure Key-Based Routing" is broken. This fixes it with a new url. 

Maybe we should just host these on IPFS?